### PR TITLE
Fix concurrent-ruby version to 1.3.4 for older Rails versions

### DIFF
--- a/gemfiles/Gemfile.rails70
+++ b/gemfiles/Gemfile.rails70
@@ -8,3 +8,6 @@ gem 'activesupport', '~> 7.0.0'
 # Rails 7.0 does not support sqlite3 2.x; it specifies gem "sqlite3", "~> 1.4"
 # in lib/active_record/connection_adapters/sqlite3_adapter.rb
 gem 'sqlite3', '~> 1.7'
+
+# Latest concurrent-ruby breaks Rails < 7.1. See https://github.com/rails/rails/issues/54260
+gem 'concurrent-ruby', '1.3.4'


### PR DESCRIPTION
This resolves test failures for Rails 7.0, caused by recently released gems.